### PR TITLE
bug fix

### DIFF
--- a/Trim-Whitespace-Change-Case-and-Split-Join-Lines.py
+++ b/Trim-Whitespace-Change-Case-and-Split-Join-Lines.py
@@ -58,7 +58,7 @@ class TEXT_OT_trim_whitespaces(Operator):
 
     @classmethod
     def poll(cls, context):
-        return (context.space_data.text and context.area.type == 'TEXT_EDITOR')
+        return (context.area.type == 'TEXT_EDITOR' and context.space_data.text)
 
     def execute(self, context):
         st = context.space_data
@@ -115,7 +115,7 @@ class TEXT_OT_convert_case(Operator):
 
     @classmethod
     def poll(cls, context):
-        return (context.space_data.text and context.area.type == 'TEXT_EDITOR')
+        return (context.area.type == 'TEXT_EDITOR' and context.space_data.text)
 
     def execute(self, context):
         st = context.space_data
@@ -170,7 +170,7 @@ class TEXT_OT_split_join_lines(Operator):
 
     @classmethod
     def poll(cls, context):
-        return (context.space_data.text and context.area.type == 'TEXT_EDITOR')
+        return (context.area.type == 'TEXT_EDITOR' and context.space_data.text)
 
     def execute(self, context):
         st = context.space_data


### PR DESCRIPTION
running another addon from text editor in 3DView with F3 was making errors in console for each operator because of the poll:
Python: Traceback (most recent call last):
  File "C:\Users\dd200\AppData\Roaming\Blender Foundation\Blender\2.91\scripts\addons\Trim-Whitespace-Change-Case-and-Split-Join-Lines.py", line 173, in poll
    return (context.space_data.text and context.area.type == 'TEXT_EDITOR')
AttributeError: 'SpaceView3D' object has no attribute 'text'
so I just inverted to check text editor area at first
NB: didn't changed the version number